### PR TITLE
moved the lodash dependency from dev to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "async": "^1.5.0",
     "minimist": "^1.2.0",
     "nano": "^6.1.5",
-    "npmlog": "^2.0.0"
+    "npmlog": "^2.0.0",
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
-    "lodash": "^3.10.1",
     "standard": "^5.4.1",
     "semantic-release": "^6.0.3"
   }


### PR DESCRIPTION
After installing the module via `npm test` the CLI usage fails because the dependency "lodash" was missing.
The reason was that in the `package.json` "lodash" was configured as dev-dependency and not install via the simple `npm install`.

The fix was simply to move the configuration into the normal dependencies - so it gets installed initially.

@gr2m btw. thanks for the module :-)
